### PR TITLE
Only use GPU devices by default

### DIFF
--- a/ufo/ufo-config.c
+++ b/ufo/ufo-config.c
@@ -261,7 +261,7 @@ ufo_config_init (UfoConfig *config)
 
     config->priv = priv = UFO_CONFIG_GET_PRIVATE (config);
     priv->path_array = g_value_array_new (0);
-    priv->device_type = UFO_DEVICE_ALL;
+    priv->device_type = UFO_DEVICE_GPU;
 
     add_path ("/usr/local/lib64/ufo", priv);
     add_path ("/usr/local/lib/ufo", priv);


### PR DESCRIPTION
On my machine, the AMD fglrx driver will expose the CPU as a computing device (even if its an Intel CPU). If no config option about the device is given, until now ufo will use the CPU together with the GPU for computing. Due to previously discussed blocking in the pipeline, this is more than factor 20 slower than using only a single GPU alone.

This commit disables CPUs for computing if not explicit config option is given.

Note: Either the AMD driver or one of the GPU boards in my machine broken - The second "GPU" reported by ufo was always the CPU device slowing everything down. I am still researching by my OS only has one GPU visible for computing.
