### PR TITLE
Fix #39: add ufo_buffer_get/set_metadata

### DIFF
--- a/tests/test-buffer.c
+++ b/tests/test-buffer.c
@@ -109,6 +109,36 @@ test_convert_16_from_data (Fixture *fixture,
         g_assert (host_data[i] == ((gfloat) fixture->data16[i]));
 }
 
+static void
+test_metadata (Fixture *fixture,
+                gconstpointer unused)
+{
+    GValue value = G_VALUE_INIT;
+    GValue *other;
+
+    g_assert (ufo_buffer_get_metadata (fixture->buffer, "bar") == NULL);
+
+    /* Insert data */
+    g_value_init (&value, G_TYPE_INT);
+    g_value_set_int (&value, -123);
+
+    ufo_buffer_set_metadata (fixture->buffer, "foo", &value);
+    other = ufo_buffer_get_metadata (fixture->buffer, "foo");
+
+    g_assert (other != NULL);
+    g_assert (g_value_get_int (other) == -123);
+
+    /* Overwrite data */
+    g_value_unset (&value);
+    g_value_init (&value, G_TYPE_FLOAT);
+    g_value_set_float (&value, 3.14f);
+    ufo_buffer_set_metadata (fixture->buffer, "foo", &value);
+
+    other = ufo_buffer_get_metadata (fixture->buffer, "foo");
+    g_assert (other != NULL);
+    g_assert (g_value_get_float (other) == 3.14f);
+}
+
 void
 test_add_buffer (void)
 {
@@ -127,4 +157,8 @@ test_add_buffer (void)
     g_test_add ("/no-opencl/buffer/convert/16/data",
                 Fixture, NULL,
                 setup, test_convert_16_from_data, teardown);
+
+    g_test_add ("/no-opencl/buffer/metadata",
+                Fixture, NULL,
+                setup, test_metadata, teardown);
 }

--- a/ufo/ufo-buffer.h
+++ b/ufo/ufo-buffer.h
@@ -154,6 +154,11 @@ void        ufo_buffer_convert              (UfoBuffer      *buffer,
 void        ufo_buffer_convert_from_data    (UfoBuffer      *buffer,
                                              gconstpointer   data,
                                              UfoBufferDepth  depth);
+GValue     *ufo_buffer_get_metadata         (UfoBuffer      *buffer,
+                                             const gchar    *name);
+void        ufo_buffer_set_metadata         (UfoBuffer      *buffer,
+                                             const gchar    *name,
+                                             GValue         *value);
 GType       ufo_buffer_get_type             (void);
 
 GParamSpec* ufo_buffer_param_spec           (const gchar*   name,


### PR DESCRIPTION
Metadata are simple key value pairs of name strings and GValue values.
