### PR TITLE
Added a function to simplify adding remotes from extern code.

### DIFF
--- a/ufo/ufo-arch-graph.c
+++ b/ufo/ufo-arch-graph.c
@@ -69,9 +69,9 @@ ufo_arch_graph_new (UfoResources *resources,
                     GList *remotes)
 {
     return UFO_GRAPH (g_object_new (UFO_TYPE_ARCH_GRAPH,
-                                    "resources", resources,
-                                    "remotes", remotes,
-                                    NULL));
+			    "resources", resources,
+			    "remotes", remotes,
+			    NULL));
 }
 
 /**

--- a/ufo/ufo-base-scheduler.c
+++ b/ufo/ufo-base-scheduler.c
@@ -126,8 +126,9 @@ ufo_base_scheduler_get_arch (UfoBaseScheduler *scheduler)
 {
     g_return_val_if_fail (UFO_IS_BASE_SCHEDULER (scheduler), NULL);
 
-    if (scheduler->priv->arch == NULL)
+    if (scheduler->priv->arch == NULL) {
         scheduler->priv->arch = UFO_ARCH_GRAPH (ufo_arch_graph_new (NULL, NULL));
+    }
 
     return scheduler->priv->arch;
 }
@@ -175,6 +176,26 @@ ufo_base_scheduler_get_gpu_nodes (UfoBaseScheduler *scheduler)
 
     return ufo_arch_graph_get_gpu_nodes (ufo_base_scheduler_get_arch (scheduler));
 }
+
+
+/**
+ * ufo_base_scheduler_set_rem_nodes:
+ * @scheduler: A #UfoBaseScheduler
+ * @arch: A #UfoArchGraph containing the remote nodes to use
+ *
+ * Sets the remote nodes for the @scheduler to use by extracting the necessary
+ * information from the #UfoArchGraph.
+ */
+void
+ufo_base_scheduler_set_rem_nodes_from_arch (UfoBaseScheduler *scheduler,
+				UfoArchGraph *arch)
+{
+	ufo_base_scheduler_set_gpu_nodes (scheduler, arch,
+					ufo_arch_graph_get_gpu_nodes(arch));
+	return;
+}
+
+
 
 static void
 ufo_base_scheduler_run_real (UfoBaseScheduler *scheduler,

--- a/ufo/ufo-base-scheduler.h
+++ b/ufo/ufo-base-scheduler.h
@@ -72,6 +72,8 @@ struct _UfoBaseSchedulerClass {
     void (*run) (UfoBaseScheduler *scheduler, UfoTaskGraph *graph, GError **error);
 };
 
+void            ufo_base_scheduler_set_rem_nodes_from_arch       (UfoBaseScheduler *scheduler,
+							UfoArchGraph  *arch);
 void            ufo_base_scheduler_run              (UfoBaseScheduler   *scheduler,
                                                      UfoTaskGraph       *task_graph,
                                                      GError            **error);

--- a/ufo/ufo-daemon.c
+++ b/ufo/ufo-daemon.c
@@ -398,10 +398,8 @@ static gpointer
 run_scheduler (UfoDaemon *daemon)
 {
     UfoDaemonPrivate *priv = UFO_DAEMON_GET_PRIVATE (daemon);
-    g_message ("Start scheduler");
     ufo_base_scheduler_run (priv->scheduler, priv->task_graph, NULL);
 
-    g_message ("Done");
     g_object_unref (priv->scheduler);
 
     priv->scheduler = ufo_scheduler_new ();


### PR DESCRIPTION
This function only needs the arch-graph, in which the remote-addresses are
handled, as an argument.
function name: ufo_base_scheduler_set_rem_nodes_from_arch (..)

Usage in python:
...
g = Ufo.ArchGraph(remotes=['tcp://127.0.0.1:5554'])
scheduler = Ufo.Scheduler()
scheduler.set_rem_nodes_from_arch (g)
...