### PR TITLE
[WIP] Add possibility to read device info (… and clean up arch/resources mess)

### DIFF
--- a/python/tests/test_infrastructure.py
+++ b/python/tests/test_infrastructure.py
@@ -60,3 +60,12 @@ def test_broadcast():
         bars = glob.glob(d.path('bar-*'))
         assert(len(foos) == 5)
         assert(len(bars) == 5)
+
+
+def test_resource_info():
+    resources = Ufo.Resources()
+    nodes = resources.get_gpu_nodes()
+    assert(nodes)
+    node = nodes[0]
+    assert(node.get_info(Ufo.GpuNodeInfo.LOCAL_MEM_SIZE) > 0)
+    assert(node.get_info(Ufo.GpuNodeInfo.GLOBAL_MEM_SIZE) > node.get_info(Ufo.GpuNodeInfo.LOCAL_MEM_SIZE))

--- a/ufo/ufo-arch-graph.h
+++ b/ufo/ufo-arch-graph.h
@@ -68,9 +68,7 @@ UfoGraph     *ufo_arch_graph_new              (UfoResources   *resources,
                                                GList          *remotes);
 UfoResources *ufo_arch_graph_get_resources    (UfoArchGraph   *graph);
 guint         ufo_arch_graph_get_num_cpus     (UfoArchGraph   *graph);
-guint         ufo_arch_graph_get_num_gpus     (UfoArchGraph   *graph);
 guint         ufo_arch_graph_get_num_remotes  (UfoArchGraph   *graph);
-GList        *ufo_arch_graph_get_gpu_nodes    (UfoArchGraph   *graph);
 GList        *ufo_arch_graph_get_remote_nodes (UfoArchGraph   *graph);
 GType         ufo_arch_graph_get_type         (void);
 

--- a/ufo/ufo-base-scheduler.c
+++ b/ufo/ufo-base-scheduler.c
@@ -176,7 +176,7 @@ ufo_base_scheduler_get_gpu_nodes (UfoBaseScheduler *scheduler)
     if (scheduler->priv->gpu_nodes != NULL)
         return scheduler->priv->gpu_nodes;
 
-    return ufo_arch_graph_get_gpu_nodes (ufo_base_scheduler_get_arch (scheduler));
+    return ufo_resources_get_gpu_nodes (ufo_arch_graph_get_resources (ufo_base_scheduler_get_arch (scheduler)));
 }
 
 
@@ -192,9 +192,8 @@ void
 ufo_base_scheduler_set_rem_nodes_from_arch (UfoBaseScheduler *scheduler,
 				UfoArchGraph *arch)
 {
-	ufo_base_scheduler_set_gpu_nodes (scheduler, arch,
-					ufo_arch_graph_get_gpu_nodes(arch));
-	return;
+	/* ufo_base_scheduler_set_gpu_nodes (scheduler, arch, */
+	/* 				ufo_arch_graph_get_gpu_nodes(arch)); */
 }
 
 

--- a/ufo/ufo-base-scheduler.c
+++ b/ufo/ufo-base-scheduler.c
@@ -161,26 +161,6 @@ ufo_base_scheduler_set_gpu_nodes (UfoBaseScheduler *scheduler,
 }
 
 /**
- * ufo_base_scheduler_get_gpu_nodes:
- * @scheduler: A #UfoBaseScheduler
- *
- * Get the GPU nodes that @scheduler can use for execution.
- *
- * Returns: (transfer none) (element-type Ufo.GpuNode): A list of #UfoGpuNode objects.
- */
-GList *
-ufo_base_scheduler_get_gpu_nodes (UfoBaseScheduler *scheduler)
-{
-    g_return_val_if_fail (UFO_IS_BASE_SCHEDULER (scheduler), NULL);
-
-    if (scheduler->priv->gpu_nodes != NULL)
-        return scheduler->priv->gpu_nodes;
-
-    return ufo_resources_get_gpu_nodes (ufo_arch_graph_get_resources (ufo_base_scheduler_get_arch (scheduler)));
-}
-
-
-/**
  * ufo_base_scheduler_set_rem_nodes:
  * @scheduler: A #UfoBaseScheduler
  * @arch: A #UfoArchGraph containing the remote nodes to use
@@ -195,8 +175,6 @@ ufo_base_scheduler_set_rem_nodes_from_arch (UfoBaseScheduler *scheduler,
 	/* ufo_base_scheduler_set_gpu_nodes (scheduler, arch, */
 	/* 				ufo_arch_graph_get_gpu_nodes(arch)); */
 }
-
-
 
 static void
 ufo_base_scheduler_run_real (UfoBaseScheduler *scheduler,

--- a/ufo/ufo-base-scheduler.h
+++ b/ufo/ufo-base-scheduler.h
@@ -82,7 +82,6 @@ UfoArchGraph   *ufo_base_scheduler_get_arch         (UfoBaseScheduler   *schedul
 void            ufo_base_scheduler_set_gpu_nodes    (UfoBaseScheduler   *scheduler,
                                                      UfoArchGraph       *arch,
                                                      GList              *gpu_nodes);
-GList          *ufo_base_scheduler_get_gpu_nodes    (UfoBaseScheduler   *scheduler);
 GType           ufo_base_scheduler_get_type         (void);
 GQuark          ufo_base_scheduler_error_quark      (void);
 

--- a/ufo/ufo-fixed-scheduler.c
+++ b/ufo/ufo-fixed-scheduler.c
@@ -438,7 +438,7 @@ setup_tasks (UfoGraph *graph,
     data->tasks = NULL;
 
     nodes = ufo_graph_get_nodes (graph);
-    gpu_nodes = ufo_base_scheduler_get_gpu_nodes (scheduler);
+    gpu_nodes = ufo_resources_get_gpu_nodes (resources);
 
     g_list_for (nodes, it) {
         UfoNode *source_node;

--- a/ufo/ufo-gpu-node.c
+++ b/ufo/ufo-gpu-node.c
@@ -18,6 +18,7 @@
  */
 
 #include <CL/cl.h>
+#include <string.h>
 #include <ufo/ufo-resources.h>
 #include <ufo/ufo-gpu-node.h>
 
@@ -67,6 +68,43 @@ ufo_gpu_node_get_cmd_queue (UfoGpuNode *node)
 {
     g_return_val_if_fail (UFO_IS_GPU_NODE (node), NULL);
     return node->priv->cmd_queue;
+}
+
+/**
+ * ufo_gpu_node_get_info:
+ * @node: A #UfoGpuNodeInfo
+ * @info: Information to be queried
+ *
+ * Return information about the associated OpenCL device.
+ *
+ * Returns: (transfer full): Information about @info.
+ */
+GValue *
+ufo_gpu_node_get_info (UfoGpuNode *node,
+                       UfoGpuNodeInfo info)
+{
+    UfoGpuNodePrivate *priv;
+    GValue *value;
+    cl_ulong ulong_value;
+
+    priv = UFO_GPU_NODE_GET_PRIVATE (node);
+    value = g_new0 (GValue, 1);
+    memset (value, 0, sizeof (GValue));
+
+    g_value_init (value, G_TYPE_ULONG);
+
+    switch (info) {
+        case UFO_GPU_NODE_INFO_GLOBAL_MEM_SIZE:
+            UFO_RESOURCES_CHECK_CLERR (clGetDeviceInfo (priv->device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof (cl_ulong), &ulong_value, NULL));
+            break;
+
+        case UFO_GPU_NODE_INFO_LOCAL_MEM_SIZE:
+            UFO_RESOURCES_CHECK_CLERR (clGetDeviceInfo (priv->device, CL_DEVICE_LOCAL_MEM_SIZE, sizeof (cl_ulong), &ulong_value, NULL));
+            break;
+    }
+
+    g_value_set_ulong (value, ulong_value);
+    return value;
 }
 
 static UfoNode *

--- a/ufo/ufo-gpu-node.h
+++ b/ufo/ufo-gpu-node.h
@@ -62,7 +62,8 @@ struct _UfoGpuNodeClass {
     UfoNodeClass parent_class;
 };
 
-UfoNode  *ufo_gpu_node_new              (gpointer    cmd_queue);
+UfoNode  *ufo_gpu_node_new              (gpointer    context,
+                                         gpointer    device);
 gpointer  ufo_gpu_node_get_cmd_queue    (UfoGpuNode *node);
 GType     ufo_gpu_node_get_type         (void);
 

--- a/ufo/ufo-gpu-node.h
+++ b/ufo/ufo-gpu-node.h
@@ -62,9 +62,24 @@ struct _UfoGpuNodeClass {
     UfoNodeClass parent_class;
 };
 
-UfoNode  *ufo_gpu_node_new              (gpointer    context,
-                                         gpointer    device);
-gpointer  ufo_gpu_node_get_cmd_queue    (UfoGpuNode *node);
+/**
+ * UfoGpuNodeInfo:
+ * @UFO_GPU_NODE_INFO_GLOBAL_MEM_SIZE: Global memory size
+ * @UFO_GPU_NODE_INFO_LOCAL_MEM_SIZE: Local memory size
+ *
+ * OpenCL device info types. Refer to the OpenCL standard for complete details
+ * about each information.
+ */
+typedef enum {
+    UFO_GPU_NODE_INFO_GLOBAL_MEM_SIZE = 0,
+    UFO_GPU_NODE_INFO_LOCAL_MEM_SIZE,
+} UfoGpuNodeInfo;
+
+UfoNode  *ufo_gpu_node_new              (gpointer        context,
+                                         gpointer        device);
+gpointer  ufo_gpu_node_get_cmd_queue    (UfoGpuNode     *node);
+GValue   *ufo_gpu_node_get_info         (UfoGpuNode     *node,
+                                         UfoGpuNodeInfo  info);
 GType     ufo_gpu_node_get_type         (void);
 
 G_END_DECLS

--- a/ufo/ufo-local-scheduler.c
+++ b/ufo/ufo-local-scheduler.c
@@ -363,7 +363,7 @@ ufo_local_scheduler_run (UfoBaseScheduler *scheduler,
 
     arch = ufo_base_scheduler_get_arch (scheduler);
     resources = ufo_arch_graph_get_resources (arch);
-    gpu_nodes = ufo_base_scheduler_get_gpu_nodes (scheduler);
+    gpu_nodes = ufo_resources_get_gpu_nodes (resources);
     pp = ufo_pp_new (gpu_nodes);
     g_list_free (gpu_nodes);
 

--- a/ufo/ufo-resources.h
+++ b/ufo/ufo-resources.h
@@ -136,7 +136,7 @@ gpointer         ufo_resources_get_kernel_from_source   (UfoResources   *resourc
 gpointer         ufo_resources_get_context              (UfoResources   *resources);
 GList          * ufo_resources_get_cmd_queues           (UfoResources   *resources);
 GList          * ufo_resources_get_devices              (UfoResources   *resources);
-GHashTable     * ufo_resources_get_mapped_cmd_queues    (UfoResources   *resources);
+GList          * ufo_resources_get_gpu_nodes            (UfoResources   *resources);
 const gchar    * ufo_resources_clerr                    (int             error);
 GType            ufo_resources_get_type                 (void);
 GQuark           ufo_resources_error_quark              (void);

--- a/ufo/ufo-scheduler.c
+++ b/ufo/ufo-scheduler.c
@@ -595,6 +595,7 @@ ufo_scheduler_run (UfoBaseScheduler *scheduler,
 {
     UfoSchedulerPrivate *priv;
     UfoArchGraph *arch;
+    UfoResources *resources;
     UfoTaskGraph *graph;
     GList *gpu_nodes;
     GList *groups;
@@ -613,7 +614,8 @@ ufo_scheduler_run (UfoBaseScheduler *scheduler,
 
     graph = task_graph;
     arch = ufo_base_scheduler_get_arch (scheduler);
-    gpu_nodes = ufo_base_scheduler_get_gpu_nodes (scheduler);
+    resources = ufo_arch_graph_get_resources (arch);
+    gpu_nodes = ufo_resources_get_gpu_nodes (resources);
 
     if (priv->mode == UFO_REMOTE_MODE_REPLICATE) {
         replicate_task_graph (graph, arch);


### PR DESCRIPTION
This PR changes the ownership of two things: GPU nodes are now managed by a Resources object whereas the command queue itself is managed by a GPU node. Moreover, we now have `ufo_gpu_node_get_info` to retrieve information with the associated device.

@tfarago: see `python/tests/test_infrastructure.py` to see how this would be used from Python.