### PR TITLE
Add shared host to reduce copy latencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ import numpy
 from setuptools import setup, Extension
 
 
-VERSION = '1.0.1'
+VERSION = '1.1.0'
 
 
 if not pkgconfig.installed('pygobject-3.0', '>=3.2.2') and \

--- a/python/src/ufo.c
+++ b/python/src/ufo.c
@@ -109,10 +109,33 @@ fromarray_inplace (PyObject *self, PyObject *args)
     return Py_BuildValue("");
 }
 
+static PyObject *
+empty_like (PyObject *self, PyObject *args)
+{
+    PyArrayObject *np_array;
+    guint np_ndims;
+    npy_intp *np_dims;
+    UfoRequisition req;
+
+    if (!PyArg_ParseTuple (args, "O!", &PyArray_Type, &np_array))
+        return NULL;
+
+    np_ndims = PyArray_NDIM (np_array);
+    np_dims = PyArray_DIMS (np_array);
+
+    req.n_dims = np_ndims;
+
+    for (guint i = 0; i < np_ndims; i++)
+        req.dims[i] = np_dims[np_ndims - 1 - i];
+
+    return pygobject_new (G_OBJECT (ufo_buffer_new (&req, NULL)));
+}
+
 static PyMethodDef exported_methods[] = {
     {"asarray",             asarray,            METH_VARARGS, "Convert UfoBuffer to Numpy array"},
     {"fromarray",           fromarray,          METH_VARARGS, "Convert Numpy array to UfoBuffer"},
     {"fromarray_inplace",   fromarray_inplace,  METH_VARARGS, "Convert Numpy array to UfoBuffer in-place"},
+    {"empty_like",          empty_like,         METH_VARARGS, "Create UfoBuffer with dimensions of NumPy array"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/python/ufo/__init__.py
+++ b/python/ufo/__init__.py
@@ -7,7 +7,7 @@ import threading
 import Queue as queue
 import numpy as np
 from gi.repository import GObject, Ufo
-from .numpy import asarray, fromarray, fromarray_inplace
+from .numpy import asarray, empty_like
 
 
 Ufo.Scheduler()
@@ -62,11 +62,11 @@ class Task(object):
                 for args in zip(*iargs):
                     for i, (task, data) in enumerate(zip(tasks, args)):
                         if buffers[i] is None:
-                            buffers[i] = fromarray(data.astype(np.float32))
+                            buffers[i] = empty_like(data)
                         else:
                             buffers[i] = task.get_input_buffer()
-                            fromarray_inplace(buffers[i], data.astype(np.float32))
 
+                        buffers[i].set_host_array(data.__array_interface__['data'][0], False)
                         task.release_input_buffer(buffers[i])
 
                 for task in tasks:

--- a/python/ufo/numpy.py
+++ b/python/ufo/numpy.py
@@ -1,1 +1,1 @@
-from _ufo import asarray, fromarray, fromarray_inplace
+from _ufo import asarray, fromarray, fromarray_inplace, empty_like

--- a/ufo/ufo-buffer.c
+++ b/ufo/ufo-buffer.c
@@ -725,7 +725,7 @@ update_location (UfoBufferPrivate *priv,
 /**
  * ufo_buffer_set_host_array:
  * @buffer: A #UfoBuffer
- * @array: A pointer to a float array with suitable size.
+ * @array: (type gulong): A pointer to a float array with suitable size.
  * @free_data: %TRUE if @buffer is supposed to clean up the host array.
  *
  * Use this function to set a host array with a user-provided memory buffer.
@@ -733,7 +733,7 @@ update_location (UfoBufferPrivate *priv,
  * consumer. Note, that the buffer *must* have an appropriate size.
  */
 void
-ufo_buffer_set_host_array (UfoBuffer *buffer, gfloat *array, gboolean free_data)
+ufo_buffer_set_host_array (UfoBuffer *buffer, gpointer array, gboolean free_data)
 {
     UfoBufferPrivate *priv;
 

--- a/ufo/ufo-buffer.h
+++ b/ufo/ufo-buffer.h
@@ -127,7 +127,7 @@ void        ufo_buffer_copy                 (UfoBuffer      *src,
                                              UfoBuffer      *dst);
 UfoBuffer  *ufo_buffer_dup                  (UfoBuffer      *buffer);
 void        ufo_buffer_set_host_array       (UfoBuffer      *buffer,
-                                             gfloat         *array,
+                                             gpointer        array,
                                              gboolean        free_data);
 gfloat*     ufo_buffer_get_host_array       (UfoBuffer      *buffer,
                                              gpointer        cmd_queue);


### PR DESCRIPTION
@tfarago: although I don't have the best feeling about sharing pointers for a longer time (unlike let's say our Concert-libuca bridge), it works for me. Using `empty_like` offers more flexibility than our initial idea of something like `fromptr`. Anyway, you can see how you'd use it in the second commit.

If it works for you, I'll merge this.