### PR TITLE
Fixed ufo-arch-graph getting passed wrong data type for param remotes

### DIFF
--- a/ufo/ufo-arch-graph.c
+++ b/ufo/ufo-arch-graph.c
@@ -56,14 +56,14 @@ static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 /**
  * ufo_arch_graph_new:
  * @resources: (allow-none): An initialized #UfoResources object or %NULL
- * @remotes: (element-type utf8): (allow-none): A #GList containing
+ * @remotes: (array) (element-type utf8) (allow-none): A #GValueArray containing
  *      address strings.
  *
  * Returns: A new #UfoArchGraph.
  */
 UfoGraph *
 ufo_arch_graph_new (UfoResources *resources,
-                    GList *remotes)
+                    GValueArray *remotes)
 {
     return UFO_GRAPH (g_object_new (UFO_TYPE_ARCH_GRAPH,
 			    "resources", resources,

--- a/ufo/ufo-arch-graph.h
+++ b/ufo/ufo-arch-graph.h
@@ -65,7 +65,7 @@ struct _UfoArchGraphClass {
 };
 
 UfoGraph     *ufo_arch_graph_new              (UfoResources   *resources,
-                                               GList          *remotes);
+                                               GValueArray    *remotes);
 UfoResources *ufo_arch_graph_get_resources    (UfoArchGraph   *graph);
 guint         ufo_arch_graph_get_num_cpus     (UfoArchGraph   *graph);
 guint         ufo_arch_graph_get_num_remotes  (UfoArchGraph   *graph);

--- a/ufo/ufo-base-scheduler.c
+++ b/ufo/ufo-base-scheduler.c
@@ -136,6 +136,26 @@ ufo_base_scheduler_get_arch (UfoBaseScheduler *scheduler)
 }
 
 /**
+ * ufo_base_scheduler_set_arch:
+ * @scheduler: A #UfoBaseScheduler
+ * @arch: A #UfoArchGraph
+ *
+ * Set ArchGraph to use in @scheduler.
+ */
+void
+ufo_base_scheduler_set_arch (UfoBaseScheduler *scheduler,
+                             UfoArchGraph *arch)
+{
+    g_return_val_if_fail (UFO_IS_BASE_SCHEDULER (scheduler), NULL);
+    g_return_val_if_fail (UFO_IS_ARCH_GRAPH (arch), NULL);
+
+    if (scheduler->priv->arch != NULL)
+        g_object_unref (scheduler->priv->arch);
+
+    scheduler->priv->arch = g_object_ref (arch);
+}
+
+/**
  * ufo_base_scheduler_set_gpu_nodes:
  * @scheduler: A #UfoBaseScheduler
  * @arch: A #UfoArchGraph from which the nodes come from

--- a/ufo/ufo-base-scheduler.h
+++ b/ufo/ufo-base-scheduler.h
@@ -78,6 +78,8 @@ void            ufo_base_scheduler_set_rem_nodes_from_arch
 void            ufo_base_scheduler_run              (UfoBaseScheduler   *scheduler,
                                                      UfoTaskGraph       *task_graph,
                                                      GError            **error);
+void            ufo_base_scheduler_set_arch         (UfoBaseScheduler   *scheduler,
+                                                     UfoArchGraph       *arch);
 UfoArchGraph   *ufo_base_scheduler_get_arch         (UfoBaseScheduler   *scheduler);
 void            ufo_base_scheduler_set_gpu_nodes    (UfoBaseScheduler   *scheduler,
                                                      UfoArchGraph       *arch,

--- a/ufo/ufo-messenger-iface.c
+++ b/ufo/ufo-messenger-iface.c
@@ -67,7 +67,7 @@ ufo_messenger_error_quark ()
 
 /**
  * ufo_messenger_connect:
- * @msger: The messenger object
+ * @messenger: The messenger object
  * @addr: (transfer none) : The address to connect. This is implementation specific.
  * @role: The role of the local endpoint (client or server).
  * @error: (allow-none): Location for a #GError or %NULL.
@@ -75,23 +75,23 @@ ufo_messenger_error_quark ()
  * Connects a messenger to and endpoint.
  */
 void
-ufo_messenger_connect (UfoMessenger *msger,
+ufo_messenger_connect (UfoMessenger *messenger,
                        const gchar *addr,
                        UfoMessengerRole role,
                        GError **error)
 {
-    UFO_MESSENGER_GET_IFACE (msger)->connect (msger, addr, role, error);
+    UFO_MESSENGER_GET_IFACE (messenger)->connect (messenger, addr, role, error);
 }
 
 void
-ufo_messenger_disconnect (UfoMessenger *msger)
+ufo_messenger_disconnect (UfoMessenger *messenger)
 {
-    UFO_MESSENGER_GET_IFACE (msger)->disconnect (msger);
+    UFO_MESSENGER_GET_IFACE (messenger)->disconnect (messenger);
 }
 
 /**
  * ufo_messenger_send_blocking: (skip)
- * @msger: The messenger object
+ * @messenger: The messenger object
  * @request: (transfer none): The request #UfoMessage.
  * @error: A #GError
  *
@@ -101,16 +101,16 @@ ufo_messenger_disconnect (UfoMessenger *msger)
  * endpoint and blocks until the message want fully sent.
  */
 UfoMessage *
-ufo_messenger_send_blocking (UfoMessenger *msger,
+ufo_messenger_send_blocking (UfoMessenger *messenger,
                              UfoMessage *request,
                              GError **error)
 {
-    return UFO_MESSENGER_GET_IFACE (msger)->send_blocking (msger, request, error);
+    return UFO_MESSENGER_GET_IFACE (messenger)->send_blocking (messenger, request, error);
 }
 
 /**
  * ufo_messenger_recv_blocking: (skip)
- * @msger: The messenger object.
+ * @messenger: The messenger object.
  * @error: The #GError object
  *
  * Returns: The received #UfoMessage.
@@ -120,10 +120,10 @@ ufo_messenger_send_blocking (UfoMessenger *msger,
  *
  */
 UfoMessage *
-ufo_messenger_recv_blocking (UfoMessenger *msger,
+ufo_messenger_recv_blocking (UfoMessenger *messenger,
                             GError **error)
 {
-    return UFO_MESSENGER_GET_IFACE (msger)->recv_blocking (msger, error);
+    return UFO_MESSENGER_GET_IFACE (messenger)->recv_blocking (messenger, error);
 }
 
 static void

--- a/ufo/ufo-messenger-iface.c
+++ b/ufo/ufo-messenger-iface.c
@@ -43,6 +43,7 @@ ufo_message_new (UfoMessageType type, guint64 data_size)
     UfoMessage *msg = g_malloc (sizeof (UfoMessage));
     msg->type = type;
     msg->data_size = data_size;
+
     if (data_size == 0)
         msg->data = NULL;
     else

--- a/ufo/ufo-messenger-iface.h
+++ b/ufo/ufo-messenger-iface.h
@@ -62,19 +62,26 @@ typedef struct _UfoMessage           UfoMessage;
  *
  */
 typedef enum {
+    /*
+     * NOTE: Make sure the order is kept intact and corresponds to the handlers
+     * entries in ufo-daemon.c.
+     */
+    /* Requests */
     UFO_MESSAGE_STREAM_JSON = 0,
     UFO_MESSAGE_REPLICATE_JSON,
     UFO_MESSAGE_GET_NUM_DEVICES,
     UFO_MESSAGE_GET_STRUCTURE,
-    UFO_MESSAGE_STRUCTURE,
     UFO_MESSAGE_GET_REQUISITION,
-    UFO_MESSAGE_REQUISITION,
     UFO_MESSAGE_SEND_INPUTS,
     UFO_MESSAGE_GET_RESULT,
-    UFO_MESSAGE_RESULT,
     UFO_MESSAGE_CLEANUP,
     UFO_MESSAGE_TERMINATE,
-    UFO_MESSAGE_ACK
+    UFO_MESSAGE_INVALID_REQUEST,
+    /* Replies */
+    UFO_MESSAGE_STRUCTURE,
+    UFO_MESSAGE_REQUISITION,
+    UFO_MESSAGE_RESULT,
+    UFO_MESSAGE_ACK,
 } UfoMessageType;
 
 /**
@@ -117,34 +124,34 @@ struct _UfoMessengerIface {
     /*< private >*/
     GTypeInterface parent_iface;
 
-    void (*connect)                         (UfoMessenger       *msger,
+    void (*connect)                         (UfoMessenger       *messenger,
                                              const gchar        *addr,
                                              UfoMessengerRole    role,
                                              GError            **error);
 
-    void (*disconnect)                      (UfoMessenger       *msger);
+    void (*disconnect)                      (UfoMessenger       *messenger);
 
-    UfoMessage * (*send_blocking)           (UfoMessenger       *msger,
+    UfoMessage * (*send_blocking)           (UfoMessenger       *messenger,
                                              UfoMessage         *request,
                                              GError            **error);
 
-    UfoMessage * (*recv_blocking)           (UfoMessenger       *msger,
+    UfoMessage * (*recv_blocking)           (UfoMessenger       *messenger,
                                              GError            **error);
 };
 
 
-void        ufo_messenger_connect           (UfoMessenger       *msger,
+void        ufo_messenger_connect           (UfoMessenger       *messenger,
                                              const gchar        *addr,
                                              UfoMessengerRole    role,
                                              GError            **error);
 
-void        ufo_messenger_disconnect        (UfoMessenger       *msger);
+void        ufo_messenger_disconnect        (UfoMessenger       *messenger);
 
-UfoMessage *ufo_messenger_send_blocking     (UfoMessenger       *msger,
+UfoMessage *ufo_messenger_send_blocking     (UfoMessenger       *messenger,
                                              UfoMessage         *request,
                                              GError            **error);
 
-UfoMessage *ufo_messenger_recv_blocking     (UfoMessenger       *msger,
+UfoMessage *ufo_messenger_recv_blocking     (UfoMessenger       *messenger,
                                              GError            **error);
 
 GQuark      ufo_messenger_error_quark       (void);

--- a/ufo/ufo-remote-node.c
+++ b/ufo/ufo-remote-node.c
@@ -193,7 +193,7 @@ ufo_remote_node_send_inputs (UfoRemoteNode *node,
 
     // determine our total message size
     guint64 size = 0;
-    
+
     for (guint i = 0; i < priv->n_inputs; i++) {
         guint64 buffer_size = ufo_buffer_get_size (inputs[i]);
         size += buffer_size;
@@ -219,7 +219,6 @@ ufo_remote_node_send_inputs (UfoRemoteNode *node,
     request->data = buffer;
     // send as a single message
     ufo_messenger_send_blocking (priv->msger, request, NULL);
-
 }
 
 void
@@ -291,7 +290,7 @@ ufo_remote_node_terminate (UfoRemoteNode *node)
     ufo_messenger_send_blocking (priv->msger, request, NULL);
 
     ufo_messenger_disconnect (priv->msger);
-    return; 
+    return;
 }
 
 static void
@@ -330,6 +329,6 @@ ufo_remote_node_init (UfoRemoteNode *self)
 {
     UfoRemoteNodePrivate *priv;
     self->priv = priv = UFO_REMOTE_NODE_GET_PRIVATE (self);
-    priv->n_inputs = 0; 
+    priv->n_inputs = 1;
     priv->terminated = FALSE;
 }


### PR DESCRIPTION
I found that the ```UfoArchGraph``` expects a ```GList``` for the _remotes_ argument, but handles it like a _boxed type_ ```GValueArray```, so I have fixed the function declaration and definitions.
This does not change the GIR binding, but it changes the C interface. What is your feeling about this? I guess, since the clustering was broken anyways, I don' think there will be too many people being affected by this API change.

Also, just to make sure: This is a pull request into the ```fix-cluster``` feature branch. Not into the mainline.