### PR TITLE
Changed ufo-resources remotes property to no longer be construction-only

### DIFF
--- a/ufo/ufo-resources.c
+++ b/ufo/ufo-resources.c
@@ -1094,8 +1094,8 @@ ufo_resources_class_init (UfoResourcesClass *klass)
                                                        "Remote address",
                                                        "Remote address",
                                                        "tcp://127.0.0.1:5554",
-                                                       G_PARAM_CONSTRUCT_ONLY | G_PARAM_READABLE),
-                                  G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
+                                                       G_PARAM_READABLE),
+                                  G_PARAM_READWRITE);
 
     for (guint i = PROP_0 + 1; i < N_PROPERTIES; i++)
         g_object_class_install_property (oclass, i, properties[i]);


### PR DESCRIPTION
The old _arch-graph_ somehow needed the ```remotes``` at construction time, thus it made sense to set them to ```G_PARAM_CONSTRUCT_ONLY```, but now that they are in _ufo-resources_ they do not need to be construction-only any more. This makes it easier to just create an _ufo-resources_ object and just do a standard ```g_object_set_property``` on it later on.