### PR TITLE
profiler: Allow blocking ufo_profiler_call

### DIFF
--- a/ufo/ufo-profiler.h
+++ b/ufo/ufo-profiler.h
@@ -127,6 +127,12 @@ void         ufo_profiler_call          (UfoProfiler        *profiler,
                                          guint               work_dim,
                                          const gsize        *global_work_size,
                                          const gsize        *local_work_size);
+void         ufo_profiler_call_blocking (UfoProfiler        *profiler,
+                                         gpointer            command_queue,
+                                         gpointer            kernel,
+                                         guint               work_dim,
+                                         const gsize        *global_work_size,
+                                         const gsize        *local_work_size);
 void         ufo_profiler_register_event
                                         (UfoProfiler *profiler,
                                          gpointer command_queue,


### PR DESCRIPTION
Enable explicit waiting on the host side until kernel execution ends. BTW this will need an ugly follow-up PR in ufo-filters. But sed is our friend...