### PR TITLE
Notify input stopped

### DIFF
--- a/docs/manual/devel.rst
+++ b/docs/manual/devel.rst
@@ -168,6 +168,25 @@ task.
     and re-build any internal data structures off of these parameters.
 
 
+Actions performed after inputs have stopped
+-------------------------------------------
+
+.. highlight:: c
+
+Every filter can listen to the ``inputs_stopped`` signal which is emitted when
+no more input data will come. By registering a callback function for this
+signal, your filter can execute cleanup actions which need to be done prior to
+filter destruction. This is typically useful when tasks are referenced in a
+multithreaded application from an outside environment, like Python. It could
+happen that an outside thread waits for a task to do something with an input,
+but if that input never comes, the outside thread might block forever. For
+instance, this might happen when ``ufo_output_task_get_output_buffer`` of the
+``OutputTask`` is called. Thus, the task listens to the ``inputs_stopped``
+signal and stops blocking the outside caller when it arrives. If you need to
+execute such cleanup actions, call ``g_signal_connect (self, "inputs_stopped",
+(GCallback) your_callback_func, NULL)`` in the ``init`` function of your task.
+
+
 Additional source files
 -----------------------
 

--- a/ufo/ufo-fixed-scheduler.c
+++ b/ufo/ufo-fixed-scheduler.c
@@ -267,8 +267,10 @@ process_loop (TaskData *data, GError **error)
     while (active) {
         active = pop_input_data (in_queues, finished, inputs, n_inputs);
 
-        if (!active)
+        if (!active) {
+            ufo_task_inputs_stopped_callback (data->task);
             break;
+        }
 
         ufo_task_get_requisition (data->task, inputs, &requisition, &tmp_error);
 
@@ -347,8 +349,10 @@ reduce_loop (TaskData *data, GError **error)
     }
 
     /* Read first input item */
-    if (!pop_input_data (in_queues, finished, inputs, n_inputs))
+    if (!pop_input_data (in_queues, finished, inputs, n_inputs)) {
+        ufo_task_inputs_stopped_callback (data->task);
         return;
+    }
 
     ufo_task_get_requisition (data->task, inputs, &requisition, &tmp_error);
 
@@ -376,6 +380,9 @@ reduce_loop (TaskData *data, GError **error)
                     go_on = ufo_task_process (data->task, inputs, outputs[i], &requisition);
                     release_input_data (in_queues, inputs, n_inputs);
                     active = pop_input_data (in_queues, finished, inputs, n_inputs);
+                    if (!active) {
+                        ufo_task_inputs_stopped_callback (data->task);
+                    }
                     go_on = go_on && active;
                 }
             } while (go_on);

--- a/ufo/ufo-group-scheduler.c
+++ b/ufo/ufo-group-scheduler.c
@@ -349,8 +349,10 @@ run_group (TaskGroup *group)
         /* Fetch data from parent groups */
         active = pop_input_data (group->parents, inputs);
 
-        if (!active)
+        if (!active) {
+            ufo_task_inputs_stopped_callback (task);
             break;
+        }
 
         /* Choose next task of the group */
         current = schedule_next (group, current);
@@ -401,6 +403,9 @@ run_group (TaskGroup *group)
                 active = ufo_task_process (task, inputs, output, &requisition);
                 release_input_data (group->parents, inputs);
                 active = pop_input_data (group->parents, inputs);
+                if (!active) {
+                    ufo_task_inputs_stopped_callback (task);
+                }
             } while (active);
 
             /* Generate and forward as long as reductor produces data */

--- a/ufo/ufo-local-scheduler.c
+++ b/ufo/ufo-local-scheduler.c
@@ -180,8 +180,10 @@ run_local (TaskLocal *local)
         /* Fetch data from parent locals */
         active = pop_input_data (local, inputs);
 
-        if (!active)
+        if (!active) {
+            ufo_task_inputs_stopped_callback (task);
             break;
+        }
 
         /* Choose next task of the local */
         /* profiler = ufo_task_node_get_profiler (UFO_TASK_NODE (task)); */
@@ -226,6 +228,9 @@ run_local (TaskLocal *local)
                 active = ufo_task_process (task, inputs, output, &requisition);
                 release_input_data (local, inputs);
                 active = pop_input_data (local, inputs);
+                if (!active) {
+                    ufo_task_inputs_stopped_callback (task);
+                }
             } while (active);
 
             /* Generate and forward as long as reductor produces data */

--- a/ufo/ufo-scheduler.c
+++ b/ufo/ufo-scheduler.c
@@ -177,6 +177,7 @@ run_task (TaskLocalData *tld)
         active = get_inputs (tld, inputs);
 
         if (!active) {
+            ufo_task_inputs_stopped_callback (tld->task);
             ufo_group_finish (group);
             break;
         }
@@ -216,6 +217,9 @@ run_task (TaskLocalData *tld)
 
                         release_inputs (tld, inputs);
                         active = get_inputs (tld, inputs);
+                        if (!active) {
+                            ufo_task_inputs_stopped_callback (tld->task);
+                        }
                         go_on = go_on && active;
                     } while (go_on);
 

--- a/ufo/ufo-task-iface.c
+++ b/ufo/ufo-task-iface.c
@@ -46,6 +46,7 @@ G_DEFINE_INTERFACE (UfoTask, ufo_task, G_TYPE_OBJECT)
 enum {
     PROCESSED,
     GENERATED,
+    INPUTS_STOPPED,
     LAST_SIGNAL
 };
 
@@ -172,6 +173,12 @@ ufo_task_generate (UfoTask *task,
     return result;
 }
 
+void
+ufo_task_inputs_stopped_callback (UfoTask *task)
+{
+    emit_signal (task, signals[INPUTS_STOPPED], 0);
+}
+
 gboolean
 ufo_task_uses_gpu (UfoTask *task)
 {
@@ -279,6 +286,13 @@ ufo_task_default_init (UfoTaskInterface *iface)
 
     signals[GENERATED] =
         g_signal_new ("generated",
+                      G_TYPE_FROM_INTERFACE (iface),
+                      G_SIGNAL_RUN_FIRST | G_SIGNAL_NO_RECURSE,
+                      0,
+                      NULL, NULL, g_cclosure_marshal_VOID__VOID,
+                      G_TYPE_NONE, 0);
+    signals[INPUTS_STOPPED] =
+        g_signal_new ("inputs_stopped",
                       G_TYPE_FROM_INTERFACE (iface),
                       G_SIGNAL_RUN_FIRST | G_SIGNAL_NO_RECURSE,
                       0,

--- a/ufo/ufo-task-iface.h
+++ b/ufo/ufo-task-iface.h
@@ -137,6 +137,8 @@ gboolean ufo_task_process           (UfoTask        *task,
 gboolean ufo_task_generate          (UfoTask        *task,
                                      UfoBuffer      *output,
                                      UfoRequisition *requisition);
+void ufo_task_inputs_stopped_callback
+                                    (UfoTask        *task);
 gboolean ufo_task_uses_gpu          (UfoTask        *task);
 gboolean ufo_task_uses_cpu          (UfoTask        *task);
 


### PR DESCRIPTION
Currently the tasks have no way to know that there won't be anymore input, which prevents clean-up actions. E.g. the `OutputTask` would block forever if a remote thread wants to get data but it won't be available.