### PR TITLE
Propagate graph expand and related copying errors

### DIFF
--- a/tests/unit/test-graph.c
+++ b/tests/unit/test-graph.c
@@ -247,7 +247,7 @@ test_expansion (Fixture *fixture, gconstpointer data)
     path = g_list_append (path, fixture->target1);
     path = g_list_append (path, fixture->target2);
 
-    ufo_graph_expand (fixture->sequence, path);
+    ufo_graph_expand (fixture->sequence, path, NULL);
     g_list_free (path);
 
     successors = ufo_graph_get_successors (fixture->sequence, fixture->root);

--- a/ufo/ufo-graph.h
+++ b/ufo/ufo-graph.h
@@ -114,7 +114,8 @@ GList      *ufo_graph_find_longest_path     (UfoGraph       *graph,
                                              UfoFilterPredicate pred,
                                              gpointer        user_data);
 void        ufo_graph_expand                (UfoGraph       *graph,
-                                             GList          *path);
+                                             GList          *path,
+                                             GError         **error);
 void        ufo_graph_dump_dot              (UfoGraph       *graph,
                                              const gchar    *filename);
 GType       ufo_graph_get_type              (void);

--- a/ufo/ufo-scheduler.c
+++ b/ufo/ufo-scheduler.c
@@ -554,10 +554,15 @@ ufo_scheduler_run (UfoBaseScheduler *scheduler,
     gpu_nodes = ufo_resources_get_gpu_nodes (resources);
 
     if (expand) {
-        if (!priv->ran)
-            ufo_task_graph_expand (graph, resources, g_list_length (gpu_nodes));
-        else
+        if (!priv->ran) {
+            ufo_task_graph_expand (graph, resources, g_list_length (gpu_nodes), error);
+            if (error && (*error != NULL)) {
+                return;
+            }
+        }
+        else {
             g_debug ("Task graph already expanded, skipping.");
+        }
     }
 
     propagate_partition (graph);

--- a/ufo/ufo-task-graph.h
+++ b/ufo/ufo-task-graph.h
@@ -92,7 +92,8 @@ void         ufo_task_graph_map                 (UfoTaskGraph       *graph,
                                                  GList              *gpu_nodes);
 void         ufo_task_graph_expand              (UfoTaskGraph       *graph,
                                                  UfoResources       *resources,
-                                                 guint               n_gpus);
+                                                 guint               n_gpus,
+                                                 GError             **error);
 void         ufo_task_graph_connect_nodes       (UfoTaskGraph       *graph,
                                                  UfoTaskNode        *n1,
                                                  UfoTaskNode        *n2);

--- a/ufo/ufo-task-iface.c
+++ b/ufo/ufo-task-iface.c
@@ -56,6 +56,7 @@ static guint signals[LAST_SIGNAL] = { 0 };
  * UfoTaskError:
  * @UFO_TASK_ERROR_SETUP: Error during setup of a task.
  * @UFO_TASK_ERROR_GET_REQUISITION: Error while trying to get the size of a
+ * @UFO_TASK_ERROR_COPY: Error during copying of a task.
  *  buffer.
  */
 GQuark

--- a/ufo/ufo-task-iface.h
+++ b/ufo/ufo-task-iface.h
@@ -45,6 +45,7 @@ typedef struct _UfoTaskIface    UfoTaskIface;
 typedef enum {
     UFO_TASK_ERROR_SETUP,
     UFO_TASK_ERROR_GET_REQUISITION,
+    UFO_TASK_ERROR_COPY,
 } UfoTaskError;
 
 /**


### PR DESCRIPTION
Some tasks, like `opencl-reduce` cannot be copied, i.e. a graph cannot be expanded and currently there was no way the erro could "bubble up".