### PR TITLE
Meson: Use python module for python dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,14 +19,10 @@ gobject_dep = dependency('gobject-2.0', version: '>= 2.38')
 gmodule_dep = dependency('gmodule-2.0', version: '>= 2.38')
 json_dep = dependency('json-glib-1.0', version: '>= 0.10.0')
 gtk_doc_dep = dependency('gtk-doc', required: false)
-# Python3.8 requires python3-embed
-python_dep = dependency('python3-embed', required: false)
-if not python_dep.found()
-  python_dep = dependency('python3', required: false)
-endif
-if not python_dep.found()
-  python_dep = dependency('python', required: false)
-endif
+
+pymod = import('python')
+python = pymod.find_installation(get_option('python'))
+python_dep = python.dependency(required: false)
 
 opencl_dep = dependency('OpenCL', required: false)
 

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ gtk_doc_dep = dependency('gtk-doc', required: false)
 
 pymod = import('python')
 python = pymod.find_installation(get_option('python'))
-python_dep = python.dependency(required: false)
+python_dep = python.dependency(required: false, embed: true)
 
 opencl_dep = dependency('OpenCL', required: false)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,8 @@ option('bashcompletiondir',
 option('ufo_max_input_nodes',
     type: 'integer', value: 64,
     description: 'Maximum number of allowed input nodes for a task')
+
+option('python',
+    type : 'string',
+    value : 'python3',
+    description : 'Name of python executable')


### PR DESCRIPTION
Use mesons python module, https://mesonbuild.com/Python-module.html, to create the python dependency object.

Allows to specify which python version to use by using the meson option `python`, for example `meson build -Dpython=python3.9`. This is important if there are more than one python version installed on the system, as it is commonly the case in Centos 7/8 systems.