### PR TITLE
Python: modernize build files and metadata

### DIFF
--- a/python/meson.build
+++ b/python/meson.build
@@ -1,0 +1,10 @@
+project('ufo-python', 'c',
+        default_options : ['c_std=c99', 'warning_level=3'],
+        version : '1.1.0')
+
+pymod = import('python')
+py3 = pymod.find_installation(required : true)
+py3_dep = py3.dependency()
+
+subdir('src')
+subdir('ufo')

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = 'ufo'
+authors = [
+  { name = 'Matthias Vogelgesang', email = 'matthias.vogelgesang@kit.edu'},
+]
+requires_python = '>=3.7'
+version = '1.1.0'
+
+[project.urls]
+homepage = 'http://ufo.kit.edu'
+
+[build-system]
+requires = ['meson', 'ninja', 'meson-python', 'numpy']
+build-backend = 'mesonpy'

--- a/python/src/meson.build
+++ b/python/src/meson.build
@@ -1,0 +1,24 @@
+pygobject_dep = dependency('pygobject-3.0', version : '>=3.2.2')
+ufo_dep = dependency('ufo', version : '>=0.4.0')
+
+incdir_numpy = run_command(py3,
+  [
+    '-c',
+    'import numpy; print(numpy.get_include())'
+  ],
+  check: true
+).stdout().strip()
+
+inc_np = include_directories(incdir_numpy)
+np_dep = declare_dependency(include_directories: inc_np)
+
+src = ['ufo.c']
+
+dependencies = [py3_dep, np_dep, ufo_dep, pygobject_dep]
+
+mod = py3.extension_module('_ufo',
+    sources : src,
+    dependencies : dependencies,
+    install : true,
+    subdir : 'ufo'
+)

--- a/python/ufo/meson.build
+++ b/python/ufo/meson.build
@@ -1,0 +1,9 @@
+py3.install_sources([
+    '__init__.py',
+    'numpy.py',
+    'tomopy.py'
+    ],
+    pure : false,
+    subdir : 'ufo'
+  )
+

--- a/python/ufo/numpy.py
+++ b/python/ufo/numpy.py
@@ -1,1 +1,1 @@
-from _ufo import asarray, fromarray, fromarray_inplace, empty_like
+from ._ufo import asarray, fromarray, fromarray_inplace, empty_like


### PR DESCRIPTION
- add meson buildfiles
- add PEP517 and PEP621 definitions

Allows to install python bindings via pip install .