### PR TITLE
chore: Explicit ABI versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ set(UFO_VERSION_MAJOR "0")
 set(UFO_VERSION_MINOR "17")
 set(UFO_VERSION_PATCH "0")
 set(UFO_VERSION "${UFO_VERSION_MAJOR}.${UFO_VERSION_MINOR}.${UFO_VERSION_PATCH}")
-set(UFO_GIR_VERSION "${UFO_VERSION_MAJOR}.0")
+
+# UFO_ABI_VERSION is introduced to manage ABI changes.
+set(UFO_ABI_VERSION "1.0")
+set(UFO_GIR_VERSION "${UFO_ABI_VERSION}")
 #}}}
 #{{{ CMake
 enable_testing()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ufo-core (0.10.0-0ubuntu1) UNRELEASED; urgency=medium
+
+  * Introduce ABI versioning
+
+ -- Chandan Sarkar <chandan.sarkar@kit.edu>  Thu, 28 Aug 2025 17:31:26 +0200
+
 ufo-core (0.10.0-0) unstable; urgency=low
 
   * Initial release (Closes: #nnnn)

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,9 @@ version_major = components[0]
 version_minor = components[1]
 version_patch = components[2]
 
+# abi_version is introduced to manage ABI changes.
+abi_version = '1.0'
+
 cc = meson.get_compiler('c')
 
 gnome = import('gnome')

--- a/ufo/CMakeLists.txt
+++ b/ufo/CMakeLists.txt
@@ -78,7 +78,7 @@ add_library(ufo SHARED ${ufocore_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/ufo-enums.c)
 
 set_target_properties(ufo PROPERTIES
     VERSION ${UFO_VERSION}
-    SOVERSION ${UFO_VERSION_MAJOR})
+    SOVERSION ${UFO_ABI_VERSION})
 
 target_link_libraries(ufo ${UFOCORE_DEPS})
 

--- a/ufo/meson.build
+++ b/ufo/meson.build
@@ -81,7 +81,7 @@ lib = library('ufo',
     sources: sources,
     dependencies: deps + [m_dep],
     version: version,
-    soversion: version_major,
+    soversion: abi_version,
     include_directories: include_dir,
     install: true,
 )
@@ -97,7 +97,7 @@ gir = find_program('g-ir-scanner', required: false)
 if gir.found() and get_option('introspection')
     gnome.generate_gir(lib,
         namespace: 'Ufo',
-        nsversion: '@0@.0'.format(version_major),
+        nsversion: abi_version,
         sources: sources + headers,
         install: true,
         includes: [
@@ -113,7 +113,7 @@ pkg = import('pkgconfig')
 
 pkg.generate(
     libraries: [lib],
-    version: version,
+    version: abi_version,
     name: 'ufo',
     description: 'Library for unified scientific camera access',
     requires: [

--- a/ufo/ufo.pc.in
+++ b/ufo/ufo.pc.in
@@ -9,7 +9,7 @@ kerneldir=${prefix}/@CMAKE_INSTALL_KERNELDIR@
 
 Name: @UFO_NAME@
 Description: @UFO_DESCRIPTION_SUMMARY@
-Version: @UFO_VERSION@
+Version: @UFO_ABI_VERSION@
 Libs: -L${libdir} -lufo
 Cflags: -I${includedir}
 Requires: glib-2.0 gobject-2.0 gmodule-2.0 gio-2.0 json-glib-1.0


### PR DESCRIPTION
Premise: With this PR we would like to introduce ABI versioning. We have added explicit variables `abi_version` for meson and `UFO_ABI_VERSION` for cmake in onctext of #164 . These variables should be kept updated in context of ABI changes.

Following is my understanding of the issue. We made some breaking changes in the past for function signatures, which is not reflected in our versioning scheme according to best practices of Debian packages. Since we inferred the version of the shared library (.so), gi-repository and pkgconfig from major release version and it did not change so far, ABI changes were also not captured.

In linux system if I have developed a Python application using some shared C library tied to a specific ABI version of Debian package (such as the situation here) and if there comes a breaking change with a newer ABI version my application should not break. Similarly, if I have two versions of the package (locally built and installed via package manager) I should be able to distinguish between them using ABI version while developing my application. Such breaking changes should be highlighted with major version change.

If above assumption is correct then in this PR we are trying to introduce a dedicated ABI version (1.0) which should be kept updated in context of breaking changes. In the following example this is reflected as newly built  libufo.so.1.0, Ufo-1.0.typelib and pkgconfig.

```bash
$ ls -l ~/.local/lib/x86_64-linux-gnu/
total 1576
drwxr-xr-x 5 nj4412 LAS-Users-IDM   4096 Aug 28 17:16 ./
drwxr-xr-x 4 nj4412 LAS-Users-IDM   4096 Okt  9  2024 ../
drwxr-xr-x 2 nj4412 LAS-Users-IDM   4096 Aug 28 17:16 girepository-1.0/
-rwxr-xr-x 1 root   root          393408 Aug 26 17:50 liboclfft.so*
lrwxrwxrwx 1 root   root              13 Aug 28 17:16 libufo.so -> libufo.so.1.0*
lrwxrwxrwx 1 root   root              16 Jan  8  2025 libufo.so.0 -> libufo.so.0.16.0*
-rwxr-xr-x 1 root   root          595648 Jan  8  2025 libufo.so.0.16.0*
-rwxr-xr-x 1 root   root          595656 Aug 28 17:15 libufo.so.0.17.0*
lrwxrwxrwx 1 root   root              16 Aug 28 17:16 libufo.so.1.0 -> libufo.so.0.17.0*
drwxr-xr-x 2 nj4412 LAS-Users-IDM   4096 Aug 28 17:16 pkgconfig/
drwxr-xr-x 2 root   root            4096 Aug 26 17:50 ufo/

$ ls -l ~/.local/lib/x86_64-linux-gnu/girepository-1.0/
total 80
drwxr-xr-x 2 nj4412 LAS-Users-IDM  4096 Aug 28 17:16 ./
drwxr-xr-x 5 nj4412 LAS-Users-IDM  4096 Aug 28 17:16 ../
-rw-r--r-- 1 root   root          36732 Jan  8  2025 Ufo-0.0.typelib
-rw-r--r-- 1 root   root          36740 Aug 28 17:15 Ufo-1.0.typelib

$ cat ~/.local/lib/x86_64-linux-gnu/pkgconfig/ufo.pc
prefix=/home/ws/nj4412/.local
includedir=${prefix}/include
libdir=${prefix}/lib/x86_64-linux-gnu

plugindir=${libdir}/ufo
kerneldir=${prefix}/share/ufo

Name: ufo
Description: Library for unified scientific camera access
Version: 1.0
Requires: glib-2.0 >=  2.38, gobject-2.0 >=  2.38, gmodule-2.0 >=  2.38, gio-2.0 >=  2.38, json-glib-1.0 >=  0.10.0
Requires.private: OpenCL, python-3.10-embed
Libs: -L${libdir} -lufo
Libs.private: -lm
Cflags: -I${includedir}/ufo-0

$ pkg-config --modversion ufo
1.0
```